### PR TITLE
Use project local prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "add:android": "test -d ios || npx cap add android",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "format": "prettier --write \"**/*.{js,ts,vue,json}\""
+    "format": "npx prettier --write \"**/*.{js,ts,vue,json}\""
   },
   "engines": {
     "node": ">=19.0.0"


### PR DESCRIPTION
Invoking `prettier` can end up using an unexpected version if the local environment is running a different version globally. Use `npx` to explicitly use the prettier version defined in this project.

This is not expected to have any functional change for a consistent environment. The only context where this would yield a different output is if a developer previously had an old version of Prettier installed globally and this command ended up invoking that global version.