### PR TITLE
docker to docker local run of web and backend improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ There are two ways to run the application locally: using Docker (recommended) or
 
 ### Option 1: Using Docker (Recommended)
 
+Note: If you are developing on Mac with an Apple Silicon chip, you should change in the Dockerfile
+```bash
+@rollup/rollup-linux-x64-musl ->  npm install rollup
+```
+to get the install running locally due to the different underlying chip architetcure.
+
 Prerequisites:
 - Docker
 - Docker Compose
@@ -40,6 +46,9 @@ cd ag-map-client
 ```
 
 2. **Start the development server**:
+
+You can configure if your locally run web app calls the online running API backend or locally run version in the nuxt.config.ts file apiUrl section. Default is set to call locally if not deployed in production.
+
 ```bash
 docker-compose up
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-
 services:
   app:
     container_name: ag-map-client

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,7 +6,7 @@ export default defineNuxtConfig({
       apiUrl:
         process.env.NODE_ENV === 'production'
           ? 'https://map-data-int.airgradient.com/map/api/v1'
-          : 'https://map-data-int.airgradient.com/map/api/v1'
+          : 'http://localhost:3001/map/api/v1'
     }
   },
   css: [


### PR DESCRIPTION
    - notes to Apple silicon users on local changes needed
    - if not production, call the locally run api as a backend (vs it used to call the web deployed backend in any other case than production deploy)