### PR TITLE
fix(docker-compose-dev): correct knexfile.ts volumn mapping

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -32,7 +32,7 @@ services:
       - ./apps/api/.env.development:/app/.env.development
       - ./apps/api/src:/app/src
       - ./apps/api/database:/app/database
-      - ./apps/api/knexfile.ts:/app/
+      - ./apps/api/knexfile.ts:/app/knexfile.ts
     command: npm run start:dev
     depends_on:
       - postgrex


### PR DESCRIPTION
The current `docker-compose-dev.yml` fails with this error

```
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/host_mnt/Users/uun/Nextcloud/agd/airgradient-map/apps/api/knexfile.ts" to rootfs at "/app": mount src=/host_mnt/Users/uun/Nextcloud/agd/airgradient-map/apps/api/knexfile.ts, dst=/app, dstFd=/proc/thread-self/fd/8, flags=0x5000: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
```