### PR TITLE
Fix location history endpoint discarding latest partial-bucket data

### DIFF
--- a/apps/api/src/location/location.service.ts
+++ b/apps/api/src/location/location.service.ts
@@ -55,7 +55,12 @@ export class LocationService {
     try {
       this.logger.debug(`Time range before processed: ${start} -- ${end}`);
       startTime = roundToBucket(start, bucketSize as BucketSize);
-      endTime = roundToBucket(end, bucketSize as BucketSize);
+      endTime = DateTime.fromISO(end, { setZone: true });
+
+      // Ensure the conversion was successful before proceeding.
+      if (!endTime.isValid) {
+        throw new Error('Invalid ISO end date string provided.');
+      }
     } catch (error) {
       this.logger.error(error);
       throw new InternalServerErrorException({


### PR DESCRIPTION
Solve this issue #394 by

1. Preserve the predefined start time and end time of bucket e.g. [.00 .15 .30 .45] for 15 mins bucket
2. Also include the latest partial-bucket data even if it is not full bucket yet