### PR TITLE
Change the database-defined SRID from 3857 to 4326

### DIFF
--- a/apps/api/database/data/location.csv
+++ b/apps/api/database/data/location.csv
@@ -2958,7 +2958,7 @@
 5042108,1,157875,Small Sensor,Buraq integrated solutions,Asia/Tashkent,POINT (73.068119 33.643208),2025-05-06 08:30:01.956,,"{""CC BY-SA 4.0""}",AirGradient,AirGradient
 10626813,1,161952,Small Sensor,"Trường Đại học Khoa học Tự nhiên, ĐHQG-HCM, Cơ sở Linh Trung.",Asia/Bangkok,POINT (106.797617 10.876939),2025-06-15 04:00:01.719,,"{""CC BY-SA 4.0""}",AirGradient,AirGradient
 11167308,2,1282,Reference,Antofagasta,America/Santiago,POINT (-70.383315682411 -23.61354215815),2025-07-30 00:00:33.277,,{},OpenAQ,Chile - SINCA
-10742032,1,161967,Small Sensor,The Lake,America/Winnipeg,POINT (9553012 501635.1),2025-06-16 00:00:01.649,,"{""CC BY-SA 4.0""}",AirGradient,AirGradient
+10742032,1,161967,Small Sensor,The Lake,America/Winnipeg,POINT (85.81616688977198 4.501626219067588),2025-06-16 00:00:01.649,,"{""CC BY-SA 4.0""}",AirGradient,AirGradient
 8090713,1,81395,Small Sensor,Winn Road,Europe/Lisbon,POINT (-1.39883 50.9256),2025-05-28 14:30:01.752,,"{""CC BY-SA 4.0""}",AirGradient,AirGradient
 11167307,2,1330,Reference,Las Condes (Acreditada),America/Santiago,POINT (-70.523326784061 -33.37677352033),2025-07-30 00:00:33.277,,{},OpenAQ,Chile - SINCA
 68614,2,6888,Reference,Jackson - Clinton,America/Los_Angeles,POINT (-120.764426 38.342606),2025-03-29 00:00:12.425,,"{""US Public Domain""}",OpenAQ,AirNow

--- a/apps/api/database/migrations/20251020030000_srid_coordinate.ts
+++ b/apps/api/database/migrations/20251020030000_srid_coordinate.ts
@@ -1,0 +1,66 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // 0. Check current SRID / type of the `coordinate` column
+  const result = await knex.raw(`
+    SELECT type, srid
+    FROM geometry_columns
+    WHERE f_table_name = 'location'
+      AND f_geometry_column = 'coordinate';
+  `);
+
+  const geomInfo = result.rows[0];
+  if (!geomInfo) {
+    console.warn("⚠️ No geometry column 'coordinate' found in 'location' — skipping migration.");
+    return;
+  }
+
+  // Only continue if it's geometry(Point, 3857)
+  if (geomInfo.type !== 'POINT' || geomInfo.srid !== 3857) {
+    console.log(`ℹ️ Skipping migration — current type is ${geomInfo.type}(${geomInfo.srid}).`);
+    return;
+  }
+
+  console.log("Detected geometry(Point, 3857) — proceeding with migration.");
+
+  // 1. Backup the table (optional but recommended)
+  await knex.raw(`CREATE TABLE location_backup AS TABLE location`);
+
+  // 2. Convert the rows whose value is 3857 to 4326
+  await knex.raw(`
+    UPDATE location
+    SET coordinate = ST_SetSRID(ST_Transform(coordinate, 4326), 3857)
+    WHERE abs(ST_X(coordinate)) >= 200 AND abs(ST_Y(coordinate)) >= 200;
+  `);
+
+  // 3. Alter column type to geometry(Point, 4326)
+  await knex.raw(`
+    ALTER TABLE location
+    ALTER COLUMN coordinate TYPE geometry(Point, 4326)
+    USING ST_SetSRID(coordinate, 4326);
+  `);
+
+  // 4. Create geography-based index
+  await knex.raw(`
+    CREATE INDEX idx_location_coordinate_geog
+    ON public.location
+    USING gist ((coordinate::geography));
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  // Check if backup table exists
+  const backupExists = await knex.schema.hasTable('location_backup');
+
+  if (!backupExists) {
+    console.log("Skipping down migration — 'location_backup' does not exist.");
+    return;
+  }
+
+  console.log("🔁 Restoring from 'location_backup'...");
+
+  // Revert using the backup
+  await knex.raw(`DROP TABLE IF EXISTS location`);
+  await knex.raw(`ALTER TABLE location_backup RENAME TO location`);
+  await knex.raw(`DROP INDEX idx_location_coordinate_geog;`);
+}

--- a/apps/api/database/seeds/02_location.ts
+++ b/apps/api/database/seeds/02_location.ts
@@ -38,7 +38,7 @@ export async function seed(knex: Knex): Promise<void> {
       INSERT INTO location (
         id, owner_id, reference_id, sensor_type, location_name, 
         timezone, coordinate, deteted_at, licenses, data_source, provider
-      ) VALUES (?, ?, ?, ?, ?, ?, ST_GeomFromText(?, 3857), ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ST_GeomFromText(?, 4326), ?, ?, ?, ?)
     `,
       [
         row.id,

--- a/apps/api/src/measurement/measurement.repository.ts
+++ b/apps/api/src/measurement/measurement.repository.ts
@@ -144,7 +144,7 @@ class MeasurementRepository {
                 WHERE 
                     ST_Within(
                         coordinate,
-                        ST_MakeEnvelope($1, $2, $3, $4, 3857)
+                        ST_MakeEnvelope($1, $2, $3, $4, 4326)
                     )
                 AND
                   ${whereQuery}

--- a/apps/api/src/tasks/tasks.repository.ts
+++ b/apps/api/src/tasks/tasks.repository.ts
@@ -111,8 +111,9 @@ export class TasksRepository {
       // 1. batch_data: Uses unnest() to reconstruct rows from our columnar arrays
       // 2. insert_owner: Upserts owners first (locations need owner_id foreign key)
       // 3. location_data: Joins location data with newly created owner IDs
-      //    - ST_GeomFromText(coordinate, 3857): Converts "POINT(lng lat)" string to PostGIS geometry
-      //    - SRID 3857 (Web Mercator): Standard projection for web mapping, matches coordinate system
+      //    - ST_GeomFromText(coordinate, 4326): Converts "POINT(lng lat)" string to PostGIS geometry
+      //    - SRID 4326: (long, lat) (Unit: Degree)
+      //    - SRID 3857 (Web Mercator): Standard projection for web mapping, matches coordinate system (x, y) (Unit: Metre)
       //    - JSON licenses: Converts JSON strings back to PostgreSQL varchar[] arrays using jsonb functions
       //      WHY JSON: unnest() can't handle JavaScript arrays like ["item1","item2"] directly
       // 4. Final INSERT: Bulk insert locations with conflict resolution (ON CONFLICT DO UPDATE)
@@ -161,7 +162,7 @@ export class TasksRepository {
             ELSE ARRAY(SELECT jsonb_array_elements_text(b.licenses_json::jsonb))
           END AS licenses,
           b.timezone,
-          ST_GeomFromText(b.coordinate, 3857) AS coordinate,
+          ST_GeomFromText(b.coordinate, 4326) AS coordinate,
           b.data_source,
           b.provider
         FROM batch_data b


### PR DESCRIPTION
[Background Knowledge]
SRID: 4326 — unit: degree, coordinate format: [longitude, latitude]
SRID: 3857 — unit: metre, coordinate format: [x, y]

[Background]
We created a `location` table with the `coordinate` column defined as `public.geometry(Point, 3857)`.

However, we always treat coordinates as latitude and longitude (SRID 4326).

Fortunately, we haven't relied on the SRID so far, so it has been working until now. (I discovered this issue while working on an outlier filter that needs to compute distances between sensors.)

[Problem]
Almost all rows contain coordinates in [latitude, longitude] format, except this one:
`10742032,1,161967,Small Sensor,The Lake,America/Winnipeg,POINT (9553012 501635.1),2025-06-16 00:00:01.649,,"{""CC BY-SA 4.0""}",AirGradient,AirGradient`

[Solution]
Change the SRID of the coordinate column to 4326.