### PR TITLE
fix(knex): use \\? instead of ? to prevent $1 substitution

### DIFF
--- a/apps/api/database/migrations/20250923053204_notifications.ts
+++ b/apps/api/database/migrations/20250923053204_notifications.ts
@@ -29,7 +29,7 @@ export async function up(knex: Knex): Promise<void> {
       CONSTRAINT valid_time_format_check
         CHECK (
           scheduled_time IS NULL OR
-          scheduled_time ~ '^([01]?[0-9]|2[0-3]):[0-5][0-9]$'
+          scheduled_time ~ '^([01]\\?[0-9]|2[0-3]):[0-5][0-9]$'
         )
     );
   `);


### PR DESCRIPTION
[Problem]
The current Knex script will create 
`'^([01]$1[0-9]|2[0-3]):[0-5][0-9]$'`
instead of what we really want 
`'^([01]?[0-9]|2[0-3]):[0-5][0-9]$'`

[Cause]
Knex tries to parse `?` into parameter placeholder

[Solution]
Escape the `?` using `\\?`
- `\\` from Typescript is `\` in SQL
- `\?` in SQL is `?` in RegEx

[Note]
- This problem does not exist in prod and int -- I think it's because the prod and int did not use Knex to create notifications table yet
- As far as I understand, the change in already run migration file will not affect it's status -> Next time you run `docker exec -it mapapi-mono npx knex migrate:latest --knexfile knexfile.ts` it will not re-run this file again -- which is correct