### PR TITLE
Refactor outlier logic to be reusable and generic

### DIFF
--- a/apps/api/src/constants/outlier-column-name.ts
+++ b/apps/api/src/constants/outlier-column-name.ts
@@ -1,0 +1,13 @@
+// IMPORTANT: Enum Values must match the column name in the database
+
+import { MeasureType } from 'src/types';
+
+export const OUTLIER_COLUMN_NAME: Partial<Record<MeasureType, string>> = {
+  [MeasureType.PM25]: 'is_pm25_outlier',
+};
+
+export type MeasureTypeWithOutlier = keyof typeof OUTLIER_COLUMN_NAME;
+
+export const MEASURE_TYPES_WITH_OUTLIER: MeasureTypeWithOutlier[] = Object.keys(
+  OUTLIER_COLUMN_NAME,
+) as MeasureTypeWithOutlier[];

--- a/apps/api/src/measurement/measurement.repository.ts
+++ b/apps/api/src/measurement/measurement.repository.ts
@@ -3,6 +3,11 @@ import DatabaseService from 'src/database/database.service';
 import { MeasurementEntity } from './measurement.entity';
 import { MeasureType } from 'src/types';
 import { getMeasureValidValueRange } from 'src/utils/measureValueValidation';
+import {
+  MEASURE_TYPES_WITH_OUTLIER,
+  MeasureTypeWithOutlier,
+  OUTLIER_COLUMN_NAME,
+} from 'src/constants/outlier-column-name';
 
 @Injectable()
 class MeasurementRepository {
@@ -60,10 +65,16 @@ class MeasurementRepository {
       if (measure === MeasureType.PM25) {
         query.selectQuery = `m.pm25, m.rhum`;
         query.whereQuery = `AND m.pm25 IS NOT NULL ${validationQuery}`;
-        query.whereQuery += excludeOutliers ? ' AND m.is_pm25_outlier = false' : '';
       } else {
         query.selectQuery = `m.${measure}`;
         query.whereQuery = `AND m.${measure} IS NOT NULL ${validationQuery}`;
+      }
+
+      if (
+        excludeOutliers &&
+        MEASURE_TYPES_WITH_OUTLIER.includes(measure as MeasureTypeWithOutlier)
+      ) {
+        query.whereQuery += ` AND m.${OUTLIER_COLUMN_NAME[measure]} = false`;
       }
     }
     return query;

--- a/apps/api/src/outlier/nearby-stats.entity.ts
+++ b/apps/api/src/outlier/nearby-stats.entity.ts
@@ -1,4 +1,4 @@
-export class NearbyPm25Stats {
+export class NearbyStats {
   mean: number | null;
   stddev: number | null;
 

--- a/apps/api/src/outlier/pm25-data-point.entity.ts
+++ b/apps/api/src/outlier/pm25-data-point.entity.ts
@@ -1,8 +1,0 @@
-export class PM25DataPointEntity {
-  measuredAt: Date;
-  pm25: number;
-
-  constructor(partial: Partial<PM25DataPointEntity>) {
-    Object.assign(this, partial);
-  }
-}

--- a/apps/api/src/types/measurement/measurement.types.ts
+++ b/apps/api/src/types/measurement/measurement.types.ts
@@ -28,15 +28,16 @@ export type MeasurementClusterResult = MeasurementCluster[];
 
 /**
  * Available measurement types for filtering
+ * IMPORTANT: Enum Values must match the column name in the database
  */
 export enum MeasureType {
-  PM25 = 'pm25',
-  PM10 = 'pm10',
-  ATMP = 'atmp',
-  RHUM = 'rhum',
-  RCO2 = 'rco2',
-  O3 = 'o3',
-  NO2 = 'no2',
+  PM25 = 'pm25', // Fine particulate matter (≤2.5µm) in µg/m³
+  PM10 = 'pm10', // Coarse particulate matter (≤10µm) in µg/m³
+  ATMP = 'atmp', // Ambient temperature in °C
+  RHUM = 'rhum', // Relative humidity in %
+  RCO2 = 'rco2', // Carbon dioxide in ppm
+  O3 = 'o3', // Ozone
+  NO2 = 'no2', // Nitrogen dioxide
 }
 
 /**


### PR DESCRIPTION
1. Generalize outlier logic
1.1 Introduce `measureType` so the query can knows which column to use
1.2 Change the type hint of `dataSource` from `string` to `DataSource` for better type safety
1.3 Remove `pm25-data-point.entity.ts` since it is no longer needed

2. Introduce `OUTLIER_COLUMN_NAME` and `MEASURE_TYPES_WITH_OUTLIER` to simplify `excludeOutliersQuery`