### PR TITLE
Apply outlier filtering on rco2

### DIFF
--- a/apps/api/database/migrations/20251211030000_irrelevant_co2_filtering.ts
+++ b/apps/api/database/migrations/20251211030000_irrelevant_co2_filtering.ts
@@ -1,0 +1,40 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // Add is_rco2_outlier column in public.measurement table
+  await knex.raw('ALTER TABLE public.measurement ADD COLUMN IF NOT EXISTS is_rco2_outlier boolean NOT NULL DEFAULT false;');
+
+  /*
+    In PostgreSQL, SELECT m.* in a view does not auto-update when you add new columns to measurement. 
+    The * is expanded to an explicit column list at creation time and then stored that way.
+    The same sql command with `airgradient-map/apps/api/database/migrations/20251201060000_create_public_views.ts`
+  */
+  await knex.raw(`
+    CREATE OR REPLACE VIEW public.vw_measurement_public AS
+      SELECT m.*
+      FROM measurement m
+      JOIN location l ON m.location_id = l.id
+      JOIN data_source d ON l.data_source_id = d.id
+      WHERE d.allow_api_access = true;
+  `);
+
+}
+
+export async function down(knex: Knex): Promise<void> {
+  // Drop is_rco2_outlier column in public.measurement table
+  await knex.raw('ALTER TABLE public.measurement DROP COLUMN IF EXISTS is_rco2_outlier');
+
+  /*
+    In PostgreSQL, SELECT m.* in a view does not auto-update when you add new columns to measurement. 
+    The * is expanded to an explicit column list at creation time and then stored that way.
+    The same sql command with `airgradient-map/apps/api/database/migrations/20251201060000_create_public_views.ts`
+  */
+  await knex.raw(`
+    CREATE OR REPLACE VIEW public.vw_measurement_public AS
+      SELECT m.*
+      FROM measurement m
+      JOIN location l ON m.location_id = l.id
+      JOIN data_source d ON l.data_source_id = d.id
+      WHERE d.allow_api_access = true;
+  `);
+}

--- a/apps/api/src/constants/outlier-column-name.ts
+++ b/apps/api/src/constants/outlier-column-name.ts
@@ -4,6 +4,7 @@ import { MeasureType } from 'src/types';
 
 export const OUTLIER_COLUMN_NAME: Partial<Record<MeasureType, string>> = {
   [MeasureType.PM25]: 'is_pm25_outlier',
+  [MeasureType.RCO2]: 'is_rco2_outlier',
 };
 
 export type MeasureTypeWithOutlier = keyof typeof OUTLIER_COLUMN_NAME;

--- a/apps/api/src/location/location.repository.ts
+++ b/apps/api/src/location/location.repository.ts
@@ -174,7 +174,7 @@ class LocationRepository {
                 m.pm10,
                 m.atmp,
                 m.rhum,
-                m.rco2,
+                CASE WHEN m.is_rco2_outlier = false THEN m.rco2 ELSE NULL END AS rco2,
                 m.o3,
                 m.no2,
                 m.measured_at AS "measuredAt",
@@ -188,7 +188,7 @@ class LocationRepository {
                 OR m.pm10 IS NOT NULL
                 OR m.atmp IS NOT NULL
                 OR m.rhum IS NOT NULL
-                OR m.rco2 IS NOT NULL
+                OR (m.is_rco2_outlier = false AND m.rco2 IS NOT NULL)
                 OR m.o3 IS NOT NULL
                 OR m.no2 IS NOT NULL
               );

--- a/apps/api/src/measurement/measurement.repository.ts
+++ b/apps/api/src/measurement/measurement.repository.ts
@@ -25,11 +25,14 @@ class MeasurementRepository {
     minVal: number | null;
     maxVal: number | null;
   } {
-    let selectQuery = 'm.pm10, m.atmp, m.rhum, m.rco2, m.o3, m.no2, ';
-
-    selectQuery += excludeOutliers
-      ? 'CASE WHEN m.is_pm25_outlier = false THEN m.pm25 ELSE NULL END AS pm25'
-      : 'm.pm25';
+    const selectQuery = `
+      ${excludeOutliers ? 'CASE WHEN m.is_pm25_outlier = false THEN m.pm25 ELSE NULL END AS pm25' : 'm.pm25'},
+      m.pm10, 
+      m.atmp, 
+      m.rhum, 
+      ${excludeOutliers ? 'CASE WHEN m.is_rco2_outlier = false THEN m.rco2 ELSE NULL END AS rco2' : 'm.rco2'},
+      m.o3, 
+      m.no2`;
 
     // General where query to ensure at least one measure is present
     const whereQuery = `
@@ -38,7 +41,7 @@ class MeasurementRepository {
         OR m.pm10 IS NOT NULL
         OR m.atmp IS NOT NULL
         OR m.rhum IS NOT NULL
-        OR m.rco2 IS NOT NULL
+        OR (m.is_rco2_outlier = false AND m.rco2 IS NOT NULL)
         OR m.o3 IS NOT NULL
         OR m.no2 IS NOT NULL
       )`;

--- a/apps/api/src/outlier/outlier.service.ts
+++ b/apps/api/src/outlier/outlier.service.ts
@@ -47,6 +47,11 @@ export class OutlierService {
     measureType: MeasureType,
     dataPoints: Array<{ locationReferenceId: number; value: number; measuredAt: string }>,
   ): Promise<Map<string, boolean>> {
+    if (dataPoints.length === 0) {
+      this.logger.debug(`No dataPoints, Skipping calculateBatchIsOutlier on ${measureType}`);
+      return new Map<string, boolean>(); // empty map
+    }
+
     // Extract arrays for batch processing
     const locationReferenceIds = dataPoints.map(dp => dp.locationReferenceId);
     const measuredAts = dataPoints.map(dp => dp.measuredAt);
@@ -55,7 +60,7 @@ export class OutlierService {
     let before = Date.now();
 
     // Check 1: Same value for 24 hours (computed in database)
-    this.logger.debug('Check same value for 24 hours');
+    this.logger.debug(`Check same value for 24 hours for ${measureType}`);
     const sameValueCheckMap = await this.outlierRepository.getBatchSameValue24hCheck(
       dataSource,
       measureType,
@@ -68,7 +73,7 @@ export class OutlierService {
     before = Date.now();
 
     // Check 2: Fetch all spatial stats in one query
-    this.logger.debug('Fetch spatial statistics');
+    this.logger.debug(`Fetch spatial statistics for ${measureType}`);
     const spatialStatsMap = await this.outlierRepository.getBatchSpatialZScoreStats(
       dataSource,
       measureType,


### PR DESCRIPTION
[Migration]
1. Create `is_rco2_outlier` on `public.measurement` table
2. Recreate `public.vw_measurement_public` view because
2.1 In PostgreSQL, SELECT m.* in a view does not auto-update when you add new columns to measurement
2.2 The * is expanded to an explicit column list at creation time and then stored that way.
2.3 The same sql command with `airgradient-map/apps/api/database/migrations/20251201060000_create_public_views.ts`

[Query]
1. update query to check `m.is_rco2_outlier`
2. In `calculateBatchIsOutlier`, return empty map if dataPoints is empty: since right now only data from AirGradient has CO2