### PR TITLE
feat(outlier): use median and scaled mad instead

### DIFF
--- a/apps/api/src/outlier/nearby-stats.entity.ts
+++ b/apps/api/src/outlier/nearby-stats.entity.ts
@@ -1,9 +1,9 @@
 export class NearbyStats {
-  mean: number | null;
-  stddev: number | null;
+  median: number | null;
+  scaledMad: number | null;
 
-  constructor(mean: unknown, stddev: unknown) {
-    this.mean = mean !== null ? Number(mean) : null;
-    this.stddev = stddev !== null ? Number(stddev) : null;
+  constructor(median: unknown, scaledMad: unknown) {
+    this.median = median !== null ? Number(median) : null;
+    this.scaledMad = scaledMad !== null ? Number(scaledMad) : null;
   }
 }

--- a/apps/api/src/outlier/outlier.service.ts
+++ b/apps/api/src/outlier/outlier.service.ts
@@ -100,22 +100,22 @@ export class OutlierService {
         continue;
       }
 
-      // Check 2: Spatial Z-score outlier
+      // Check 2: Spatial robust Z-score outlier
       const stats = spatialStatsMap.get(key);
-      if (!stats || stats.mean === null || stats.stddev === null) {
+      if (!stats || stats.median === null || stats.scaledMad === null) {
         // No data available, hence not outlier
         resultsMap.set(key, false);
         continue;
       }
 
-      const { mean, stddev } = stats;
+      const { median, scaledMad } = stats;
       let isOutlier = false;
 
-      if (mean >= 50) {
-        const zScore = (value - mean) / stddev;
-        isOutlier = Math.abs(zScore) > this.Z_SCORE_THRESHOLD;
+      if (median >= 50) {
+        const robustZScore = value - median / scaledMad;
+        isOutlier = Math.abs(robustZScore) > this.Z_SCORE_THRESHOLD;
       } else {
-        isOutlier = Math.abs(value - mean) > this.ABSOLUTE_THRESHOLD;
+        isOutlier = Math.abs(value - median) > this.ABSOLUTE_THRESHOLD;
       }
 
       resultsMap.set(key, isOutlier);


### PR DESCRIPTION
[Formular]
Robust Z-score = (value - Median) / Scaled MAD

Scaled MAD here is the 1.4826 * Median Absolute Deviation to make it "normal-consistent":
- Scaled MAD = 1.4826 * MAD
- MAD = median( |x - median(x)| )

[Changes]
1. Use this `Z-score = (value - Median) / Scaled MAD` instead
1.1 Using median, make it more tolerant with very high or low value which mean can not
1.2 Using MAD is the same idea like median -- more tolerant
1.3 Use scaled MAD to map this value to the same z-score scale, so the threshold is more intuitive

2. Do not exclude outliers anymore
2.1 Because the most recent value could be incorrectly flagged as an outlier
2.2 Using a robust z-score (median + scaled MAD) makes this safe, since extreme values have much less influence on the neighborhood statistics.