### PR TITLE
fix(build): correct docker building for staging and prod

### DIFF
--- a/apps/api/nest-cli.json
+++ b/apps/api/nest-cli.json
@@ -7,7 +7,7 @@
     "assets": [
       {
         "include": "aqi-standards/aqi_standards.json",
-        "outDir": "dist/src"
+        "outDir": "dist"
       }
     ],
     "watchAssets": true

--- a/apps/api/tools/docker/Dockerfile
+++ b/apps/api/tools/docker/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 COPY tsconfig*.json ./
+COPY nest-cli.json ./
 
 # Install dependencies
 RUN npm ci

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"],
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
When build staging docker, got error

```
ERROR [AqiStandardsService] AQI standards file not found. Tried: /app/dist/aqi-standards/aqi_standards.json, /app/dist/aqi-standards/aqi_standards.json, /app/src/aqi-standards/aqi_standards.json
mapapi-mono        | [Nest] 2985  - 12/17/2025, 2:09:40 PM   ERROR [ExceptionHandler] Error: AQI standards file is missing
```

Fix
- Fixed AQI standards asset packaging by making sure nest-cli.json is used in the API Docker build and emits aqi_standards.json into dist/aqi-standards/.
- Kept the original flattened dist/ layout (tsconfig.build.json includes src/**/*) and aligned all runtime entry points (Dockerfile, docker-compose, package scripts) to dist/api-main.js and dist/cron-main.