### PR TITLE
Introduce measurement_location_time_rco2_idx partial index

### DIFF
--- a/apps/api/database/migrations/20251218000000_add_measurement_rco2_index.ts
+++ b/apps/api/database/migrations/20251218000000_add_measurement_rco2_index.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  /** Create partial index optimized for RCO2 queries
+  * This index covers the WHERE clause pattern used in /locations/:id/measures/history:
+  *   location_id for filtering by location
+  *   measured_at DESC for time range queries
+  * Partial index only includes rows where is_rco2_outlier = false AND rco2 IS NOT NULL
+  * The same idea as in `20251209000000_add_measurement_cigarettes_index.ts`
+  */
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS measurement_location_time_rco2_idx
+    ON public.measurement (location_id, measured_at DESC)
+    WHERE is_rco2_outlier = false AND rco2 IS NOT NULL
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw('DROP INDEX IF EXISTS measurement_location_time_rco2_idx');
+}


### PR DESCRIPTION
[Issue]
Right now with the outlier flag on RCO2, make `/locations/:id/measures/history` endpoint very slow -- you can try playing with 3 months history of RCO2

[Description]
This is the same situation with 3-month history of PM2.5
- location_id for filtering by location
- measured_at DESC for time range queries
- WHERE is_x_outlier = false AND x IS NOT NULL

[Solution]
Mimic the same idea that solves the same issue on PM2.5 [here](https://github.com/airgradienthq/airgradient-map/blob/main/apps/api/database/migrations/20251209000000_add_measurement_cigarettes_index.ts)